### PR TITLE
elves:turn off uniform-select for mobile units

### DIFF
--- a/techs/zetapack/factions/elves/units/elf/elf.xml
+++ b/techs/zetapack/factions/elves/units/elf/elf.xml
@@ -11,7 +11,7 @@
 		<sight value="12"/>
 		<time value="30"/>
 		<multi-selection value="true"/>
-		<uniform-selection value="true"/>
+		<uniform-selection value="false"/>
 		<cellmap value="false"/>
 		<levels/>
 		<fields>

--- a/techs/zetapack/factions/elves/units/gryphon/gryphon.xml
+++ b/techs/zetapack/factions/elves/units/gryphon/gryphon.xml
@@ -11,7 +11,7 @@
 		<sight value="20"/>
 		<time value="250"/>
 		<multi-selection value="true"/>
-		<uniform-selection value="true"/>
+		<uniform-selection value="false"/>
 		<cellmap value="false"/>
 		<levels>
 			<level name="tame" kills="4"/>

--- a/techs/zetapack/factions/elves/units/gryphon_rider/gryphon_rider.xml
+++ b/techs/zetapack/factions/elves/units/gryphon_rider/gryphon_rider.xml
@@ -11,7 +11,7 @@
 		<sight value="20"/>
 		<time value="250"/>
 		<multi-selection value="true"/>
-		<uniform-selection value="true"/>
+		<uniform-selection value="false"/>
 		<cellmap value="false"/>
 		<levels>
 			<level name="master" kills="4"/>

--- a/techs/zetapack/factions/elves/units/minstrel/minstrel.xml
+++ b/techs/zetapack/factions/elves/units/minstrel/minstrel.xml
@@ -12,7 +12,7 @@
 		<sight value="13"/>
 		<time value="120"/>
 		<multi-selection value="true"/>
-		<uniform-selection value="true"/>
+		<uniform-selection value="false"/>
 		<meeting-point value="true" image-path="../academy/images/mp.bmp"/>
 		<cellmap value="false"/>
 		<levels>

--- a/techs/zetapack/factions/elves/units/wise_elf/wise_elf.xml
+++ b/techs/zetapack/factions/elves/units/wise_elf/wise_elf.xml
@@ -11,7 +11,7 @@
 		<sight value="20"/>
 		<time value="100"/>
 		<multi-selection value="true"/>
-		<uniform-selection value="true"/>
+		<uniform-selection value="false"/>
 		<cellmap value="false"/>
 		<levels/>
 		<fields>


### PR DESCRIPTION
This should help with #54

Affects https://github.com/ZetaGlest/zetaglest-source/issues/38 and
https://github.com/ZetaGlest/zetaglest-source/issues/74

@Jammyjamjamman For the elves, this should fix the problem selecting workers when they are near building.

I think this pretty much matches how things are with MG.. Buildings have uniform-select set to "true", and mobile units are set to "false" by default. If not uniform-select tag is present, then it defaults to false.

Please test it when you get a chance, and if it works as expected, merge it.