### PR TITLE
romans:temple:reduce build speed

### DIFF
--- a/techs/zetapack/factions/romans/romans.xml
+++ b/techs/zetapack/factions/romans/romans.xml
@@ -29,9 +29,11 @@
 		<building-units>
 			<unit name="training_camp" minimum="2"/>
 			<unit name="temple" minimum="1"/>
+			<unit name="blacksmith_shop" minimum="1"/>
 		</building-units>
 		<upgrades>
 			<upgrade name="reinforce_armor"/>
+			<upgrade name="sign_of_mars"/>
 			<upgrade name="sharpen_points"/>
 			<upgrade name="bless_of_minerva"/>
 		</upgrades>

--- a/techs/zetapack/factions/romans/units/fire_archer/fire_archer.xml
+++ b/techs/zetapack/factions/romans/units/fire_archer/fire_archer.xml
@@ -21,11 +21,10 @@
 		</fields>
 		<properties/>
 		<light enabled="false"/>
-		<unit-requirements>
-			<unit name="training_camp"/>
-			<unit name="temple"/>
-		</unit-requirements>
-		<upgrade-requirements/>
+		<unit-requirements/>
+		<upgrade-requirements>
+			<upgrade name="sign_of_mars"/>
+		</upgrade-requirements>
 		<resource-requirements>
 			<resource name="wood" amount="60"/>
 			<resource name="gold" amount="130"/>

--- a/techs/zetapack/factions/romans/units/temple/temple.xml
+++ b/techs/zetapack/factions/romans/units/temple/temple.xml
@@ -9,7 +9,7 @@
 		<armor value="0" />
 		<armor-type value="stone"/>
 		<sight value="15" />
-		<time value="300" />
+		<time value="125" />
 		<multi-selection value="false" />
 		<max-unit-count value="4"/>
 		<cellmap value="true">
@@ -107,7 +107,9 @@
 			<name value="research_sign_of_mars" />
 			<image path="../../upgrades/sign_of_mars/images/marz.bmp" />
 			<unit-requirements />
-			<upgrade-requirements />
+			<upgrade-requirements>
+				<upgrade name="reinforce_armor"/>
+			</upgrade-requirements>
 			<upgrade-skill value="upgrade_skill"/>
 			<produced-upgrade name="sign_of_mars"/>
 		</command>


### PR DESCRIPTION
To compensate for the temple being built faster, fire archers require
sign_of_mars, which requires reinforce_armor. This prevents fire archers
from being available to early in the game.

https://groups.google.com/d/topic/zetaglest/D5CSfrOV7mM/discussion