### PR TITLE
catapults:increase sight

### DIFF
--- a/techs/zetapack/factions/greece/units/onager/onager.xml
+++ b/techs/zetapack/factions/greece/units/onager/onager.xml
@@ -8,7 +8,7 @@
 		<max-ep value="0"/>
 		<armor value="10"/>
 		<armor-type value="wood"/>
-		<sight value="10"/>
+		<sight value="18"/>
 		<time value="100"/>
 		<multi-selection value="true"/>
 		<uniform-selection value="false"/>

--- a/techs/zetapack/factions/romans/units/catapult/catapult.xml
+++ b/techs/zetapack/factions/romans/units/catapult/catapult.xml
@@ -9,7 +9,7 @@
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="wood"/>
-		<sight value="15"/>
+		<sight value="20"/>
 		<time value="100"/>
 		<multi-selection value="true"/>
 		<cellmap value="false"/>

--- a/techs/zetapack/factions/tech/units/catapult/catapult.xml
+++ b/techs/zetapack/factions/tech/units/catapult/catapult.xml
@@ -9,7 +9,7 @@
 		<max-ep value="0"/>
 		<armor value="10"/>
 		<armor-type value="wood"/>
-		<sight value="11"/>
+		<sight value="16"/>
 		<time value="100"/>
 		<multi-selection value="true"/>
 		<cellmap value="false"/>


### PR DESCRIPTION
The attack range of catapults was increased by
https://github.com/ZetaGlest/zetaglest-data/commit/e3b0b4999c6da4b18369c0c0f6d2a4c1bed84cb3
but the sight was not increased accordingly.