### PR TITLE
amazones:grammar, spelling

### DIFF
--- a/scenarios/amazones/amazones_english.lng
+++ b/scenarios/amazones/amazones_english.lng
@@ -3,7 +3,7 @@ SCENARIO_NAME=Amazones
 Amazones=Amazones
 
 ;message strings
-Brief1=Your allies' castle must survive!
+Brief1=Your ally's castle must survive!
 
 ;objective strings
 Firstwave=Objective: Ladies in green.

--- a/scenarios/amazones_light/amazones_light_english.lng
+++ b/scenarios/amazones_light/amazones_light_english.lng
@@ -3,7 +3,7 @@ SCENARIO_NAME=Amazones Lite
 Amazones=Amazones
 
 ;message strings
-Brief1=Your allies' castle must survive!
+Brief1=Your ally's castle must survive!
 
 ;objective strings
 Firstwave=Objective: Ladies in green.

--- a/scenarios/amazones_pro/amazones_pro_english.lng
+++ b/scenarios/amazones_pro/amazones_pro_english.lng
@@ -3,7 +3,7 @@ SCENARIO_NAME=Amazones Pro
 Amazones=Amazones
 
 ;message strings
-Brief1=Your allies' castle must survive!
+Brief1=Your ally's castle must survive!
 
 ;objective strings
 Firstwave=Objective: Ladies in green.


### PR DESCRIPTION
-allies'- should be singular possessive (ally's), not plural possessive.
Your ally's castle... You only have one ally in this scenario (even
though they don't have any units other than the castle)