### PR TITLE
wood resource:default amount 300 -> 1500

### DIFF
--- a/techs/zetapack/resources/wood/wood.xml
+++ b/techs/zetapack/resources/wood/wood.xml
@@ -3,7 +3,7 @@
 <resource>
 	<image path="images/wood.bmp"/>
 	<type value="tileset">
-		<default-amount value="300"/>
+		<default-amount value="1500"/>
 		<tileset-object value="1"/>
 	</type>
 </resource>


### PR DESCRIPTION
This will require far less trees to be added to maps, which could
potentially help reduce lagging, and increase possibilities for map
design, esp. on smaller maps.

After this is merged, plan to only edit a few maps to try it out further