### PR TITLE
magic:golems:reduce range of power golem (closes #143)

### DIFF
--- a/techs/zetapack/factions/magic/units/golem/golem.xml
+++ b/techs/zetapack/factions/magic/units/golem/golem.xml
@@ -9,7 +9,7 @@
 		<max-ep value="1000" regeneration="20" start-percentage="50"/>
 		<armor value="45"/>
 		<armor-type value="stone"/>
-		<sight value="10"/>
+		<sight value="15"/>
 		<time value="150"/>
 		<multi-selection value="true"/>
 		<cellmap value="false"/>
@@ -82,11 +82,12 @@
 			</sound>
 			<attack-strength value="200"/>
 			<attack-var value="150"/>
-			<attack-range value="10"/>
+			<attack-range value="12"/>
 			<attack-type value="impact"/>
 			<attack-start-time value="0.4"/>
 			<attack-fields>
 				<field value="land"/>
+				<field value="air"/>
 			</attack-fields>
 			<projectile value="true">
 				<particle value="true" path="particle_proj.xml"/>

--- a/techs/zetapack/factions/magic/units/power_golem/power_golem.xml
+++ b/techs/zetapack/factions/magic/units/power_golem/power_golem.xml
@@ -4,17 +4,17 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="2000" regeneration="5"/>
+		<max-hp value="3000" regeneration="5"/>
 		<max-ep value="500" regeneration="2" start-percentage="40"/>
 		<armor value="10"/>
 		<armor-type value="stone"/>
-		<sight value="20"/>
-		<time value="20"/>
+		<sight value="16"/>
+		<time value="100"/>
 		<multi-selection value="true"/>
 		<cellmap value="false"/>
 		<levels>
-			<level name="ancient" kills="10"/>
-			<level name="legendary" kills="30"/>
+			<level name="ancient" kills="7"/>
+			<level name="legendary" kills="15"/>
 		</levels>
 		<fields>
 			<field value="land"/>
@@ -80,12 +80,13 @@
 				<sound-file path="$COMMONDATAPATH/sounds/golem_walk1.wav"/>
 			</sound>
 			<attack-strength value="250"/>
-			<attack-var value="10"/>
-			<attack-range value="15"/>
+			<attack-var value="30"/>
+			<attack-range value="12"/>
 			<attack-type value="energy"/>
 			<attack-start-time value="0.4"/>
 			<attack-fields>
 				<field value="land"/>
+				<field value="air"/>
 			</attack-fields>
 			<projectile value="true">
 				<particle value="true" path="particle_proj.xml"/>


### PR DESCRIPTION
Also made a few other changes (see diff)

range is now equal to most of the other defense towers in ZG. And also
gave them air attack ability, since most defense towers have that as
well.

I'll reduce the range of catapults in a separate PR.